### PR TITLE
Fix open redirect vulnerability in SoJobLookupHandler

### DIFF
--- a/server/modules/securityonion/sojoblookuphandler.go
+++ b/server/modules/securityonion/sojoblookuphandler.go
@@ -43,8 +43,8 @@ func (handler *SoJobLookupHandler) get(writer http.ResponseWriter, request *http
   statusCode := http.StatusBadRequest
   esId := request.URL.Query().Get("esid")
   redirectUrl := request.URL.Query().Get("redirectUrl")
-  if redirectUrl == "" {
-    redirectUrl = "/"
+  if redirectUrl == "" || redirectUrl[0] != '/' {
+    redirectUrl = "/" + redirectUrl
   }
   sensorId, filter, err := handler.elastic.LookupEsId(esId)
   if err == nil {


### PR DESCRIPTION
Prevent arbitrary redirect by prepending a forward slash to the redirect target.  This forces redirects to be a relative path of the current request's host.

If possible, I would appreciate it if we could generate a security advisory and request a CVE for the vulnerability this addresses.